### PR TITLE
Render main 4 components in App

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,20 @@
 import React from 'react';
 import './styles.css';
+import Overview from './Overview';
+import Related from './Related';
+import QA from './QA';
+import Ratings from './Ratings';
 
 function App() {
   return (
-    <h1>This is my App!</h1>
+    <div>
+      <h1>This is my App!</h1>
+      <Overview />
+      <Related />
+      <QA />
+      <Ratings />
+    </div>
+
   );
 }
 

--- a/src/Overview.jsx
+++ b/src/Overview.jsx
@@ -1,0 +1,13 @@
+// index for overview subcomponents
+
+import React from 'react';
+
+function Overview() {
+  return (
+    <div>
+      Overview Module
+    </div>
+  );
+}
+
+export default Overview;

--- a/src/QA.jsx
+++ b/src/QA.jsx
@@ -1,0 +1,13 @@
+// index for q&a subcomponents
+
+import React from 'react';
+
+function QA() {
+  return (
+    <div>
+      Q & A Module
+    </div>
+  );
+}
+
+export default QA;

--- a/src/Ratings.jsx
+++ b/src/Ratings.jsx
@@ -1,0 +1,13 @@
+// index for ratings&reviews subcomponents
+
+import React from 'react';
+
+function Ratings() {
+  return (
+    <div>
+      Ratings & Reviews Module
+    </div>
+  );
+}
+
+export default Ratings;

--- a/src/Related.jsx
+++ b/src/Related.jsx
@@ -1,0 +1,13 @@
+// index for related&comparison subcomponents
+
+import React from 'react';
+
+function Related() {
+  return (
+    <div>
+      Related & Comparison Module
+    </div>
+  );
+}
+
+export default Related;


### PR DESCRIPTION
App should be able to render out each module by name, which could then render subcomponents. I have set them to be singular files for now but they could also be folders to further organize, so that subcomponents could be imported like: src/components/QA/AnswersList. The order is based off the Visual Design spec [https://xd.adobe.com/view/e600dc0f-454c-44e3-5075-7872d04189ff-9031/?fullscreen](url)