### PR TITLE
adding css module configuration and style samples

### DIFF
--- a/client/src/reviews/components/ReviewTile.jsx
+++ b/client/src/reviews/components/ReviewTile.jsx
@@ -1,11 +1,40 @@
 import React from 'react';
+import * as styles from '../reviews.module.css';
 /* eslint-disable react/prop-types */
 
 function ReviewsList({ review }) {
   return (
-    <div className="review-tile-wrapper">
-      <h2>Review Tile:</h2>
-      <p>{review.review_id}</p>
+    <div className={styles.reviewTileWrapper}>
+      <div className={styles.reviewTileHeading}>
+        <div className={styles.reviewTileStarRating}>
+          ☆☆☆☆☆:
+          {review.rating}
+        </div>
+        <div className="review-title__authorship">
+          <span className="review-title__review-user">
+            {review.reviewer_name}
+          </span>
+          <span className="review-title__review-date">
+            {review.date}
+          </span>
+        </div>
+      </div>
+      <h2 className="review-tile__summary">{review.summary}</h2>
+      <p className="review-tile__body">{review.body}</p>
+      <p className="review-tile__recommended">✓ I recommend this product</p>
+      <div className={styles.reviewTitleResponse}>
+        <h3 className={styles.reviewTitleResponseTitle}>Response: </h3>
+        <p className="review-title__response-title">{review.response}</p>
+      </div>
+      <div className="review-tile__helpfulness-footer">
+        <p className="review-tile__helpfulness-text">
+          <span className="review-tile__helpful-btn">
+            Helpful?
+            <button type="button">Yes</button>
+            {review.helpfulness}
+          </span>
+        </p>
+      </div>
     </div>
   );
 }

--- a/client/src/reviews/components/ReviewsList.jsx
+++ b/client/src/reviews/components/ReviewsList.jsx
@@ -9,6 +9,7 @@ function ReviewsList() {
 
   useEffect(() => {
     ReviewsServices.getReviews(Reviews.product, Reviews.count, Reviews.page, (data) => {
+      console.log(data.results);
       setReviews(data.results);
     });
   }, []);

--- a/client/src/reviews/reviews.module.css
+++ b/client/src/reviews/reviews.module.css
@@ -1,0 +1,25 @@
+/* reviews.module.css */
+
+.reviewTileWrapper {
+  background: rgb(250, 250, 250);
+  padding: 15px;
+  margin-bottom: 10px;
+  border: solid #ccc 1px;
+  width: 800px;
+}
+
+.reviewTileHeading {
+  display: flex;
+  justify-content: space-between;
+}
+
+.reviewTitleResponse {
+  background: #eeeeee;
+  padding: 20px;
+}
+
+.reviewTitleResponseTitle {
+  font-size: 16px;
+  margin: 0;
+  padding: 0;
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,3 +1,4 @@
 body {
-  background: teal;
+  background: #fff;
+  font-family:Arial, Helvetica, sans-serif;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,14 +23,27 @@ module.exports = {
         use: 'babel-loader',
       },
       {
-        test: /\.css$/i,
+        test: /\.module\.css$/,
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              modules: true,
+            },
+          },
+        ],
+      },
+      {
+        test: /\.css$/,
+        exclude: /\.module\.css$/,
         use: ['style-loader', 'css-loader'],
       },
     ],
   },
   plugins: [
     new HtmlWebpackPlugin({
-      title: "Greenfield",
+      title: 'Greenfield',
     }),
     // This will allow you to refer to process.env variables
     // within client-side files at build-time:


### PR DESCRIPTION
This change updates the webpack css-loader to allow for css modules and demonstrates how to pull styles (as objects) from local style sheets in a module folder. Should allow us to: 

- Keep global styles (site-wide) in client/src/styles.css
- Work on our own separate css files in individual files like reviews.module.css

NOTE: 

We have to use **import * as styles from '../reviews.module.css';** to import the module styles (must use * as)

See reference here: https://www.geeksforgeeks.org/reactjs/how-do-css-modules-help-in-styling-react-components/#utilizing-css-modules
